### PR TITLE
Fixed 3D model references

### DIFF
--- a/SOIC-16W_7.5x10.3mm_Pitch1.27mm.kicad_mod
+++ b/SOIC-16W_7.5x10.3mm_Pitch1.27mm.kicad_mod
@@ -43,7 +43,7 @@
   (pad 14 smd rect (at 4.65 -1.905) (size 1.5 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 15 smd rect (at 4.65 -3.175) (size 1.5 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 16 smd rect (at 4.65 -4.445) (size 1.5 0.6) (layers F.Cu F.Paste F.Mask))
-  (model Housings_SOIC.3dshapes/SOIC-16_7.5x10.3mm_Pitch1.27mm.wrl
+  (model ${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-16W_7.5x10.3mm_Pitch1.27mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SOIC-18W_7.5x11.6mm_Pitch1.27mm.kicad_mod
+++ b/SOIC-18W_7.5x11.6mm_Pitch1.27mm.kicad_mod
@@ -45,7 +45,7 @@
   (pad 16 smd rect (at 4.7 -2.54) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 17 smd rect (at 4.7 -3.81) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 18 smd rect (at 4.7 -5.08) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
-  (model Housings_SOIC.3dshapes/SOIC-18_7.5x11.6mm_Pitch1.27mm.wrl
+  (model ${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-18W_7.5x11.6mm_Pitch1.27mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SOIC-20W_7.5x12.8mm_Pitch1.27mm.kicad_mod
+++ b/SOIC-20W_7.5x12.8mm_Pitch1.27mm.kicad_mod
@@ -47,7 +47,7 @@
   (pad 18 smd rect (at 4.7 -3.175) (size 1.95 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 19 smd rect (at 4.7 -4.445) (size 1.95 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 20 smd rect (at 4.7 -5.715) (size 1.95 0.6) (layers F.Cu F.Paste F.Mask))
-  (model Housings_SOIC.3dshapes/SOIC-20_7.5x12.8mm_Pitch1.27mm.wrl
+  (model ${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-20W_7.5x12.8mm_Pitch1.27mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SOIC-24W_7.5x15.4mm_Pitch1.27mm.kicad_mod
+++ b/SOIC-24W_7.5x15.4mm_Pitch1.27mm.kicad_mod
@@ -51,7 +51,7 @@
   (pad 22 smd rect (at 4.7 -4.445) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 23 smd rect (at 4.7 -5.715) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 24 smd rect (at 4.7 -6.985) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
-  (model Housings_SOIC.3dshapes/SOIC-24_7.5x15.4mm_Pitch1.27mm.wrl
+  (model ${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-24W_7.5x15.4mm_Pitch1.27mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SOIC-28W_7.5x17.9mm_Pitch1.27mm.kicad_mod
+++ b/SOIC-28W_7.5x17.9mm_Pitch1.27mm.kicad_mod
@@ -55,7 +55,7 @@
   (pad 26 smd rect (at 4.7 -5.715) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 27 smd rect (at 4.7 -6.985) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 28 smd rect (at 4.7 -8.255) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
-  (model Housings_SOIC.3dshapes/SOIC-28_7.5x17.9mm_Pitch1.27mm.wrl
+  (model ${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-28W_7.5x17.9mm_Pitch1.27mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Added missing "W" to 3D model name in the following footprints.  Also added `${KISYS3DMOD}/` to fix KLC error.

```
SOIC-16W_7.5x10.3mm_Pitch1.27mm
SOIC-18W_7.5x11.6mm_Pitch1.27mm
SOIC-20W_7.5x12.8mm_Pitch1.27mm
SOIC-24W_7.5x15.4mm_Pitch1.27mm
SOIC-28W_7.5x17.9mm_Pitch1.27mm
```